### PR TITLE
Set Node requirement to 12 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "start": "tsdx watch",


### PR DESCRIPTION
This package has a dependency on `@hapi/hapi` which requires Node 12+, see https://github.com/hapijs/hapi/blob/v19.2.0/package.json#L9
So I bumped Node requirement for this package to 12 too.