### PR TITLE
Add support of Yarn 2+

### DIFF
--- a/src/installAddonBench.ts
+++ b/src/installAddonBench.ts
@@ -13,11 +13,30 @@ const insertAddonBench = (main: string) => {
 };
 
 export const installAddonBench = async () => {
-  spawnSync('yarn', ['add', '@storybook/addon-bench', '--dev', '-W'], {
+  let commandArgs = ['add', '@storybook/addon-bench', '--dev'];
+  if (isUsingYarn1()) {
+    commandArgs.push('-W');
+  }
+  spawnSync('yarn', commandArgs, {
     stdio: STDIO,
   });
   const mainFile = '.storybook/main.js';
   const main = fs.readFileSync(mainFile).toString();
   const mainWithBench = insertAddonBench(main);
   fs.writeFileSync(mainFile, mainWithBench);
+};
+
+const isUsingYarn1 = (): boolean => {
+  const yarnVersionCommand = spawnSync('yarn', ['--version']);
+
+  if (yarnVersionCommand.status !== 0) {
+    throw new Error(`🧶 Yarn must be installed to run '@storybook/bench'`);
+  }
+
+  const yarnVersion = yarnVersionCommand.output
+    .toString()
+    .replace(/,/g, '')
+    .replace(/"/g, '');
+
+  return /^1\.+/.test(yarnVersion);
 };


### PR DESCRIPTION
Yarn 2 doesn't support the `-W` option when running `yarn add`.
So I added a check to know if we are using Yarn 1 or 2 and update the command accordingly.

Related to https://github.com/storybookjs/storybook/pull/13559