### PR TITLE
Use `yarn storybook` for `sb dev` compatibility

### DIFF
--- a/src/startStorybook.ts
+++ b/src/startStorybook.ts
@@ -25,7 +25,7 @@ export const startStorybook = async (extraFlags: string[]) => {
   const stats = resetStats();
   const child = spawn(
     'yarn',
-    ['start-storybook', '-p', DEV_PORT.toString(), '--ci', ...extraFlags],
+    ['storybook', '-p', DEV_PORT.toString(), '--ci', ...extraFlags],
     {
       stdio: 'pipe',
     }
@@ -72,7 +72,7 @@ export const startStorybook = async (extraFlags: string[]) => {
   await buildFinished;
 
   const page = await browser.newPage();
-  await page.goto(`http://localhost:${DEV_PORT}/index.html`);
+  await page.goto(`http://localhost:${DEV_PORT}/`);
 
   await renderFinished;
 


### PR DESCRIPTION
There was a bug in the puppeteer URL where it requested `index.html` which was unfortunately filled in by CRA's `-s public`, which is why this approach failed on the first attempt ... 🤦‍♂️ 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.5--canary.10.3b80121.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/bench@0.7.5--canary.10.3b80121.0
  # or 
  yarn add @storybook/bench@0.7.5--canary.10.3b80121.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
