### PR TITLE
Fix triple-counting manager size

### DIFF
--- a/src/buildBrowseStorybook.ts
+++ b/src/buildBrowseStorybook.ts
@@ -44,7 +44,8 @@ const bundleSize = async (buildDir: string, prefix: string, iframeScripts: strin
   }
 
   return {
-    manager: await du(path.join(buildDir, manager)),
+    // avoid triple-counting main.manger / runtime.manager / vendors.manager
+    manager: manager === 'sb-manager' && prefix !== 'main' ? 0 : await du(path.join(buildDir, manager)),
     preview: preview ? await du(path.join(buildDir, preview)) : 0,
   };
 };


### PR DESCRIPTION
Self-merging @ndelangen 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.6--canary.16.b52bad3.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/bench@0.7.6--canary.16.b52bad3.0
  # or 
  yarn add @storybook/bench@0.7.6--canary.16.b52bad3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.0.0-next.2`

<details>
  <summary>Changelog</summary>

  #### 💥 Breaking Change
  
  - upgrades and add a handling for storybook7 which has no main.js for the manager [#12](https://github.com/storybookjs/bench/pull/12) ([@shilman](https://github.com/shilman) [@ndelangen](https://github.com/ndelangen))
  - Replace puppeteer with playwright [#11](https://github.com/storybookjs/bench/pull/11) ([@shilman](https://github.com/shilman) [@ndelangen](https://github.com/ndelangen))
  
  #### 🐛 Bug Fix
  
  - Fix triple-counting manager size [#16](https://github.com/storybookjs/bench/pull/16) ([@shilman](https://github.com/shilman))
  - Fix support for main.cjs [#14](https://github.com/storybookjs/bench/pull/14) ([@shilman](https://github.com/shilman))
  - Fix handling of millisecond startup time [#13](https://github.com/storybookjs/bench/pull/13) ([@shilman](https://github.com/shilman))
  
  #### Authors: 2
  
  - Michael Shilman ([@shilman](https://github.com/shilman))
  - Norbert de Langen ([@ndelangen](https://github.com/ndelangen))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
