### PR TITLE
Fix: race condition when there is still resources to load

### DIFF
--- a/src/buildBrowseStorybook.ts
+++ b/src/buildBrowseStorybook.ts
@@ -126,7 +126,7 @@ export const buildBrowseStorybook = async (extraFlags: string[]) => {
   });
 
   const page = await browser.newPage();
-  await page.goto(`http://localhost:${STATIC_STORYBOOK_PORT}/index.html`);
+  await page.goto(`http://localhost:${STATIC_STORYBOOK_PORT}/index.html`, { waitUntil: 'domcontentloaded' });
 
   await promise;
 

--- a/src/startStorybook.ts
+++ b/src/startStorybook.ts
@@ -92,6 +92,7 @@ export const startStorybook = async (extraFlags: string[]) => {
   await buildFinished;
 
   const page = await browser.newPage();
+  // why 'domcontentloaded' ? => https://github.com/storybookjs/bench/pull/18
   await page.goto(`http://localhost:${DEV_PORT}/`, { waitUntil: 'domcontentloaded' });
 
   await renderFinished;

--- a/src/startStorybook.ts
+++ b/src/startStorybook.ts
@@ -92,7 +92,7 @@ export const startStorybook = async (extraFlags: string[]) => {
   await buildFinished;
 
   const page = await browser.newPage();
-  await page.goto(`http://localhost:${DEV_PORT}/`);
+  await page.goto(`http://localhost:${DEV_PORT}/`, { waitUntil: 'domcontentloaded' });
 
   await renderFinished;
 


### PR DESCRIPTION
I ran into this error:
```
HANDLER: managerRender {
  init: 1671533605055,
  time: { managerRender: null, previewRender: null }
}
HANDLER: previewRender {
  init: 1671533605055,
  time: { managerRender: 14961000000, previewRender: null }
}
killing start-storybook
stopping stats server
closing browser
closing start-storybook
page.goto: Navigation failed because page was closed!
=========================== logs ===========================
navigating to "http://localhost:9999/", waiting until "load"
============================================================
    at startStorybook (/Users/me/.npm/_npx/8b410674f93e0039/node_modules/@storybook/bench/dist/bench.cjs.development.js:390:14)
    at async benchmark (/Users/me/.npm/_npx/8b410674f93e0039/node_modules/@storybook/bench/dist/bench.cjs.development.js:491:36)
    at async main (/Users/me/.npm/_npx/8b410674f93e0039/node_modules/@storybook/bench/dist/bench.cjs.development.js:527:17) {
  name: 'Error'
}
```
here: https://app.circleci.com/pipelines/github/storybookjs/storybook/36404/workflows/17fcb81c-4445-4833-93a4-9509e6d2e0be

Turns out there's a race-condition where if the browser hasn't finished loading all resources, but the request for getting the stats are both in, the browser is closed, which causes the `goto()` method to reject, because it's still waiting for the `window.onload` event.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.6--canary.18.9b6563c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/bench@0.7.6--canary.18.9b6563c.0
  # or 
  yarn add @storybook/bench@0.7.6--canary.18.9b6563c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.0.0-next.4`

<details>
  <summary>Changelog</summary>

  #### 💥 Breaking Change
  
  - upgrades and add a handling for storybook7 which has no main.js for the manager [#12](https://github.com/storybookjs/bench/pull/12) ([@shilman](https://github.com/shilman) [@ndelangen](https://github.com/ndelangen))
  - Replace puppeteer with playwright [#11](https://github.com/storybookjs/bench/pull/11) ([@shilman](https://github.com/shilman) [@ndelangen](https://github.com/ndelangen))
  
  #### 🐛 Bug Fix
  
  - Fix: race condition when there is still resources to load [#18](https://github.com/storybookjs/bench/pull/18) ([@ndelangen](https://github.com/ndelangen))
  - Use next version of addon-bench [#17](https://github.com/storybookjs/bench/pull/17) ([@shilman](https://github.com/shilman))
  - Fix triple-counting manager size [#16](https://github.com/storybookjs/bench/pull/16) ([@shilman](https://github.com/shilman))
  - Fix support for main.cjs [#14](https://github.com/storybookjs/bench/pull/14) ([@shilman](https://github.com/shilman))
  - Fix handling of millisecond startup time [#13](https://github.com/storybookjs/bench/pull/13) ([@shilman](https://github.com/shilman))
  
  #### Authors: 2
  
  - Michael Shilman ([@shilman](https://github.com/shilman))
  - Norbert de Langen ([@ndelangen](https://github.com/ndelangen))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
