### PR TITLE
Fix: instead of awaiting page load, discard error from page pre-emptive closing

### DIFF
--- a/src/startStorybook.ts
+++ b/src/startStorybook.ts
@@ -92,8 +92,11 @@ export const startStorybook = async (extraFlags: string[]) => {
   await buildFinished;
 
   const page = await browser.newPage();
-  // why 'domcontentloaded' ? => https://github.com/storybookjs/bench/pull/18
-  await page.goto(`http://localhost:${DEV_PORT}/`, { waitUntil: 'domcontentloaded' });
+
+  page.goto(`http://localhost:${DEV_PORT}/`).catch(error => {
+    console.trace(`an error occured within page.goto`);
+    console.log(error);
+  });
 
   await renderFinished;
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.6--canary.19.891f0cd.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/bench@0.7.6--canary.19.891f0cd.0
  # or 
  yarn add @storybook/bench@0.7.6--canary.19.891f0cd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
